### PR TITLE
Switch to tactile theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-seo-tag", "~> 2.8"
 end
-
-gem "minima", "~> 2.5"
+gem "jekyll-theme-tactile", "~> 0.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,9 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
+    jekyll-theme-tactile (0.2.0)
+      jekyll (> 3.5, < 5.0)
+      jekyll-seo-tag (~> 2.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.13.2)
@@ -91,10 +94,6 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    minima (2.5.2)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-feed (~> 0.9)
-      jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.2)
@@ -166,7 +165,7 @@ DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-feed (~> 0.12)
   jekyll-seo-tag (~> 2.8)
-  minima (~> 2.5)
+  jekyll-theme-tactile (~> 0.2.0)
 
 BUNDLED WITH
    2.6.7

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: "https://example.com"
 
 # Build settings
 markdown: kramdown
-theme: minima
+theme: jekyll-theme-tactile
 plugins:
   - jekyll-feed
   - jekyll-seo-tag

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: default
 title: Curriculum Vitae
 ---
 


### PR DESCRIPTION
## Summary
- use the tactile GitHub Pages theme
- adjust CV index to match the theme's layout

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68936cac7d0c832cb6aa773e3bd5eff1