### PR TITLE
Switch to Dinky GitHub Pages theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,4 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-seo-tag", "~> 2.8"
 end
-gem "jekyll-theme-tactile", "~> 0.2.0"
+gem "jekyll-theme-dinky", "~> 0.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
-    jekyll-theme-tactile (0.2.0)
+    jekyll-theme-dinky (0.2.0)
       jekyll (> 3.5, < 5.0)
       jekyll-seo-tag (~> 2.0)
     jekyll-watch (2.2.1)
@@ -165,7 +165,7 @@ DEPENDENCIES
   jekyll (~> 4.3)
   jekyll-feed (~> 0.12)
   jekyll-seo-tag (~> 2.8)
-  jekyll-theme-tactile (~> 0.2.0)
+  jekyll-theme-dinky (~> 0.2.0)
 
 BUNDLED WITH
    2.6.7

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url: "https://example.com"
 
 # Build settings
 markdown: kramdown
-theme: jekyll-theme-tactile
+theme: jekyll-theme-dinky
 plugins:
   - jekyll-feed
   - jekyll-seo-tag


### PR DESCRIPTION
## Summary
- Replace tactile theme with dinky in site config
- Update theme dependency to jekyll-theme-dinky

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6896ebb87204832ca7ae8c779176c309